### PR TITLE
change client test flag '-tt' to '-conf' according to the main README.md

### DIFF
--- a/client/README
+++ b/client/README
@@ -1,1 +1,1 @@
-go test -tt=./test-examples.conf
+go test -conf=./test-examples.conf

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	flag.StringVar(&confPath, "tt", "./test.conf", " set gosnowflake config file path")
+	flag.StringVar(&confPath, "conf", "./test.conf", " set gosnowflake config file path")
 }
 
 var (


### PR DESCRIPTION
The main README installation guide shows "go test -conf=./test-examples.conf" while the client test flag is "-tt". Then this patch generated.:)