### PR TITLE
fix README installation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ cd $GOPATH/src/github.com/Terry-Mao/gosnowflake
 # compile
 $ go install
 $ cp ./gosnowflake-example.conf $GOPATH/bin/gosnowflake.conf
+$ cp log.xml $GOPATH/bin/log.xml
 $ cd $GOPATH/bin
 # run
 $ ./gosnowflake -conf=./gosnowflake.conf


### PR DESCRIPTION
setup gosnowflake need a log.xml, which is not mentioned in README's installation.